### PR TITLE
escape troublesome characters in regexp expressions

### DIFF
--- a/lib/ebnf/rule.rb
+++ b/lib/ebnf/rule.rb
@@ -367,11 +367,11 @@ module EBNF
     def to_regexp
       case expr.first
       when :hex
-        Regexp.new(translate_codepoints(expr[1]))
+        Regexp.new(Regexp.escape(translate_codepoints(expr[1])))
       when :istr
         /#{expr.last}/ui
       when :range
-        Regexp.new("[#{translate_codepoints(expr[1])}]")
+        Regexp.new("[#{escape_regexp_character_range(translate_codepoints(expr[1]))}]")
       else
         raise "Can't turn #{expr.inspect} into a regexp"
       end
@@ -769,6 +769,12 @@ module EBNF
       @id_seq ||= 0
       @id_seq += 1
       ["_#{@sym}_#{@id_seq}#{variation}".to_sym, ("#{@id}.#{@id_seq}#{variation}" if @id)]
+    end
+
+    # Escape "[", "]", and "\" in ranges so they don't result in a warning or error
+    # about empty character classes.
+    def escape_regexp_character_range(character_range)
+      character_range.gsub(/([\[\]\\])/) {|char| "\\#{char}"}
     end
   end
 end

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -481,9 +481,13 @@ describe EBNF::Rule do
   describe "#to_regexp" do
     {
       hex: [:hex, "#x20", / /],
+      hex: [:hex, "#x5c", /\\/],
       range: [:range, "a-b", /[a-b]/],
       range2: [:range, "a-zA-Z", /[a-zA-Z]/],
       range3: [:range, "abc-", /[abc-]/],
+      range4: [:range, "#x23-#x5b", /[#-\[]/],
+      range5: [:range, "#x5d-#x5e", /[\]-^]/],
+      range6: [:range, "#x5c-#x5e", /[\\-^]/],
     }.each do |title, (op, exp, regexp)|
       it title do
         expect(EBNF::Rule.new(title, nil, [op, exp]).to_regexp).to eql regexp


### PR DESCRIPTION
Found this issue while parsing the ABNF JSON string representation. These two rules caused parsing issues because of the characters generated within the regular expressions that they result in:

```
escape    = %x5C ; \
unescaped = %x20-21 / %x23-5B / %x5D-10FFFF ; [ -!] / [#-[] / []-\u{10FFF}]
```

The `escape` rule generated a regexp of `/\/` which throws `RegexpError: too short escape sequence: /\/`.
The `unescaped` rule generated `[#-[]` which throws `RegexpError: empty char-class: /[#-[]/` and `[]-\u{10FFF}]` which works but warns with `warning: character class has ']' without escape: /[]-𐿿]/`.

