### PR TITLE
fix(native): validate range content at parse time

### DIFF
--- a/lib/ebnf/native.rb
+++ b/lib/ebnf/native.rb
@@ -291,8 +291,13 @@ module EBNF
         l, s = s[1..-1].split(m.rstrip, 2)
         [Unescape.unescape(l).tap {|str| str.quote_style = (m == "'" ? :squote : :dquote)}, s]
       when '[' # RANGE, O_RANGE
-        # Includes RANGE and O_RANGE which can't include a ']'
-        l, s = s[1..-1].split(']', 2)
+        matched = s.match(Terminals::RANGE) || s.match(Terminals::O_RANGE)
+        unless matched
+          error("terminal", "illegal range: #{s.inspect}")
+          raise SyntaxError, "illegal range: #{s.inspect}"
+        end
+        l = matched[0][1..-2]
+        s = s[matched[0].length..]
         [[:range, Unescape.unescape(l)], s]
       when '#' # HEX
         s.match(/(#x\h+)(.*)$/)

--- a/spec/native_spec.rb
+++ b/spec/native_spec.rb
@@ -128,6 +128,7 @@ describe EBNF::Native do
     {
       "diff missing second operand": %{rule ::= a -},
       "unrecognized terminal" => %{rule ::= %foo%},
+      "leading '-' in range" => %{rule ::= [-abc]},
     }.each do |title, input|
       it title do
         expect {parse(input)}.to raise_error(SyntaxError)


### PR DESCRIPTION
The native parser'ss terminal method accepted any content between [ and ] without validation. This meant invalid ranges like [-abc] were silently accepted instead of raising SyntaxError, despite the RANGE regex in terminals.rb correctly rejecting them.

